### PR TITLE
Added global kernl events to BaseSingleCacheKernl

### DIFF
--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/DefaultKernlPolicy.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/DefaultKernlPolicy.kt
@@ -3,9 +3,4 @@ package org.mattshoe.shoebox.kernl
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
-object DefaultKernlPolicy: KernlPolicy {
-    override val timeToLive = Duration.INFINITE
-    override val events: Flow<KernlEvent> = Kernl.events
-    override val cacheStrategy = CacheStrategy.NetworkFirst
-    override val invalidationStrategy = InvalidationStrategy.TakeNoAction(timeToLive = Duration.INFINITE)
-}
+object DefaultKernlPolicy: KernlPolicy by KernlPolicyDefaults.copy()

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/Kernl.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/Kernl.kt
@@ -1,17 +1,22 @@
 package org.mattshoe.shoebox.kernl
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.*
+
+private val mutableGlobalEventStream = MutableSharedFlow<KernlEvent>(
+    replay = 0,
+    extraBufferCapacity = 1,
+    onBufferOverflow = BufferOverflow.DROP_OLDEST,
+)
+
+data object GlobalKernlEventStream: SharedFlow<KernlEvent> by mutableGlobalEventStream.asSharedFlow()
 
 object Kernl {
-    private val _events = MutableSharedFlow<KernlEvent>(
-        replay = 0,
-        onBufferOverflow = BufferOverflow.SUSPEND
-    )
-    val events: Flow<KernlEvent> = _events
+    val events: Flow<KernlEvent> = GlobalKernlEventStream
 
     suspend fun globalEvent(event: KernlEvent) {
-        _events.emit(event)
+        mutableGlobalEventStream.emit(event)
+        println("derp")
     }
 }


### PR DESCRIPTION
<!-- 
Please include the issue number in the PR title.
Example: "[#] Add new feature to bar the foo"
-->

<!-- Link the issue associated with this PR -->
<!-- If no issue is associated with this PR, please create one for tracking purposes -->
# Issue  [#15](https://github.com/mattshoe/kernl/issues/15)

## Description
<!-- Briefly describe the changes introduced by this PR -->
configured BaseSingleCacheKernl to obey global kernl events

## Checklist
<!-- Replace [ ] with [x] to indicate completion -->

- **I have added tests to cover any code changes**
  - [x] Unit Tests
  - [x] Consumer Tests (Integration tests in the Kernl.Consumer module)
  - [x] Compilation Tests (Integration tests in the Kernl.Processor module for any KSP updates)
- **I have added new documentation for all new code and updated existing documentation:**
  - [x] KDocs
  - [x] README.md
  - [x]docs/*.md
- **I have updated all existing  documentation to reflect any changes:**
  - [x] KDocs
  - [x] README.md
  - [x] docs/*.md

## Additional Context
<!-- Add any other context or screenshots about the PR -->
