### PR TITLE
Implemented RetryStrategy logic

### DIFF
--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/ExponentialBackoff.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/ExponentialBackoff.kt
@@ -1,0 +1,10 @@
+package org.mattshoe.shoebox.kernl
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+data class ExponentialBackoff(
+    override val maxAttempts: Int = 3,
+    override val initialDelay: Duration = 100.milliseconds,
+    override val backoffFactor: Double = 2.0
+): RetryStrategy

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/InvalidationStrategy.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/InvalidationStrategy.kt
@@ -30,8 +30,7 @@ sealed interface InvalidationStrategy {
      * @property retries The number of times the retrieval should be retried upon invalidation in the case of failure.
      */
     data class LazyRefresh(
-        override val timeToLive: Duration = Duration.INFINITE,
-        val retries: Int = 0
+        override val timeToLive: Duration = Duration.INFINITE
     ): InvalidationStrategy
 
     /**
@@ -44,8 +43,7 @@ sealed interface InvalidationStrategy {
      * @property retries The number of times the retrieval should be retried upon invalidation in the case of failure.
      */
     data class EagerRefresh(
-        override val timeToLive: Duration = Duration.INFINITE,
-        val retries: Int = 0
+        override val timeToLive: Duration = Duration.INFINITE
     ): InvalidationStrategy
 
     /**
@@ -61,7 +59,6 @@ sealed interface InvalidationStrategy {
      */
     data class PreemptiveRefresh(
         override val timeToLive: Duration = Duration.INFINITE,
-        val leadTime: Duration,
-        val retries: Int = 0
+        val leadTime: Duration
     ): InvalidationStrategy
 }

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/KernlPolicy.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/KernlPolicy.kt
@@ -10,17 +10,15 @@ import kotlin.time.Duration
  * Implementing this interface allows you to customize how data is cached, invalidated, and refreshed.
  */
 interface KernlPolicy {
+
     /**
-     * The duration for which the cached data remains valid.
-     * After this duration, the data is considered stale and will be invalidated until it is refreshed.
+     * The strategy to employ when a data retrieval operation fails.
      *
-     * This value is used to determine the TTL (Time-To-Live) of the cache entries.
-     * For example, if the TTL is set to 5 minutes, the data will be considered valid for 5 minutes
-     * from the time it was cached.
-     *
-     * @return The duration for which the cached data is considered valid.
+     * Allows you to define how many attempts to make for each failure, along with the amount of time between
+     * subsequent requests.
      */
-    val timeToLive: Duration
+    val retryStrategy: RetryStrategy?
+
     /**
      * A flow of events that affect the cache, such as invalidation and refresh events.
      * This flow can be used to listen for, react to, and trigger changes in the cache state.

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/KernlPolicyDefaults.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/KernlPolicyDefaults.kt
@@ -5,13 +5,13 @@ import kotlin.time.Duration
 
 object KernlPolicyDefaults {
     fun copy(
-        timeToLive: Duration = Duration.INFINITE,
+        retryStrategy: RetryStrategy? = null,
         events: Flow<KernlEvent> = Kernl.events,
         cacheStrategy: CacheStrategy = CacheStrategy.NetworkFirst,
         invalidationStrategy: InvalidationStrategy = InvalidationStrategy.TakeNoAction(timeToLive = Duration.INFINITE),
     ): KernlPolicy {
         return KernlPolicyImpl(
-            timeToLive,
+            retryStrategy,
             events,
             cacheStrategy,
             invalidationStrategy
@@ -20,7 +20,7 @@ object KernlPolicyDefaults {
 }
 
 private data class KernlPolicyImpl(
-    override val timeToLive: Duration,
+    override val retryStrategy: RetryStrategy?,
     override val events: Flow<KernlEvent>,
     override val cacheStrategy: CacheStrategy,
     override val invalidationStrategy: InvalidationStrategy,

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/RetryStrategy.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/RetryStrategy.kt
@@ -1,0 +1,9 @@
+package org.mattshoe.shoebox.kernl
+
+import kotlin.time.Duration
+
+interface RetryStrategy {
+    val maxAttempts: Int
+    val initialDelay: Duration
+    val backoffFactor: Double
+}

--- a/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/RetryStrategyDefaults.kt
+++ b/Kernl.Common/src/main/kotlin/org/mattshoe/shoebox/kernl/RetryStrategyDefaults.kt
@@ -1,0 +1,24 @@
+package org.mattshoe.shoebox.kernl
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+object RetryStrategyDefaults {
+    fun copy(
+        maxAttempts: Int = 3,
+        initialDelay: Duration = 100.milliseconds,
+        backoffFactor: Double = 2.0
+    ): RetryStrategy {
+        return RetryStrategyImpl(
+            maxAttempts,
+            initialDelay,
+            backoffFactor
+        )
+    }
+}
+
+private data class RetryStrategyImpl(
+    override val maxAttempts: Int,
+    override val initialDelay: Duration,
+    override val backoffFactor: Double
+): RetryStrategy

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/singlecache/inmemory/BaseSingleCacheKernl.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/singlecache/inmemory/BaseSingleCacheKernl.kt
@@ -30,6 +30,7 @@ abstract class BaseSingleCacheKernl<TParams: Any, TData: Any>(
     private val dataSource by lazy {
         DataSource.Builder
             .memoryCache(dataType)
+            .retryStrategy(kernlPolicy.retryStrategy)
             .dispatcher(dispatcher)
             .build()
     }

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/builder/DataSourceBuilder.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/builder/DataSourceBuilder.kt
@@ -2,12 +2,19 @@ package org.mattshoe.shoebox.kernl.runtime.source.builder
 
 import org.mattshoe.shoebox.kernl.runtime.source.DataSource
 import kotlinx.coroutines.CoroutineDispatcher
+import org.mattshoe.shoebox.kernl.RetryStrategy
 import kotlin.reflect.KClass
 
 abstract class DataSourceBuilder<T: Any>(
     protected val clazz: KClass<T>
 ) {
     protected var dispatcher: CoroutineDispatcher? = null
+    protected var retryStrategy: RetryStrategy? = null
+
+    fun retryStrategy(retryStrategy: RetryStrategy?): DataSourceBuilder<T> {
+        this.retryStrategy = retryStrategy
+        return this
+    }
 
     fun dispatcher(dispatcher: CoroutineDispatcher): DataSourceBuilder<T> {
         this.dispatcher = dispatcher

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/builder/MemoryCacheDataSourceBuilder.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/builder/MemoryCacheDataSourceBuilder.kt
@@ -11,6 +11,9 @@ class MemoryCacheDataSourceBuilder<T: Any>(
     clazz
 ) {
     override fun build(): DataSource<T> {
-        return MemoryCachedDataSource(dispatcher ?: Dispatchers.IO)
+        return MemoryCachedDataSource(
+            dispatcher = dispatcher ?: Dispatchers.IO,
+            retryStrategy = retryStrategy
+        )
     }
 }

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/impl/MemoryCachedDataSource.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/source/impl/MemoryCachedDataSource.kt
@@ -61,10 +61,8 @@ internal open class MemoryCachedDataSource<T: Any>(
                 _data.emit(dataResult)
                 value = dataResult
             } catch (e: CancellationException) {
-                println("Cancelled!!! $e")
                 throw e
             } catch (e: Throwable) {
-                println("DS error: $e")
                 val dataResult = DataResult.Error<T>(e)
                 _data.emit(dataResult)
                 value = dataResult

--- a/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlIntegrationTest.kt
+++ b/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlIntegrationTest.kt
@@ -359,7 +359,7 @@ class BaseSingleCacheKernlIntegrationTest {
             eventStream.emit(KernlEvent.Invalidate(43))
             advanceUntilIdle()
             expectNoEvents()
-            
+
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlIntegrationTest.kt
+++ b/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlIntegrationTest.kt
@@ -419,6 +419,75 @@ class BaseSingleCacheKernlIntegrationTest {
         }
     }
 
+    @Test
+    fun `WHEN kernl policy has no retry strategy THEN no retry is attempted`() = runTest(StandardTestDispatcher()) {
+        val eventStream = MutableSharedFlow<KernlEvent>(replay = 1)
+        val policy = KernlPolicyDefaults.copy(
+            events = eventStream
+        )
+        val attempts = mutableListOf<Int>()
+        val subject = makeSubject(kernlPolicy = policy)
+        subject.operation = { param ->
+            attempts.add(param)
+            throw RuntimeException()
+        }
+        subject.data.test {
+            subject.fetch(42)
+            Truth.assertThat(awaitItem() is DataResult.Error).isTrue()
+            advanceUntilIdle()
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `WHEN kernl policy has ExponentialBackoff retry strategy AND first attempt fails THEN one retry is attempted`() = runTest(StandardTestDispatcher()) {
+        val eventStream = MutableSharedFlow<KernlEvent>(replay = 1)
+        val policy = KernlPolicyDefaults.copy(
+            events = eventStream,
+            retryStrategy = ExponentialBackoff()
+        )
+        val attempts = mutableListOf<Int>()
+        val subject = makeSubject(kernlPolicy = policy)
+        subject.operation = { param ->
+            if (attempts.isEmpty()) {
+                attempts.add(param)
+                throw RuntimeException()
+            } else {
+                attempts.add(param)
+                param.toString()
+            }
+        }
+        subject.data.test {
+            subject.fetch(42)
+            advanceUntilIdle()
+            Truth.assertThat(awaitItem() is Success).isTrue()
+            Truth.assertThat(attempts.size).isEqualTo(2)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `WHEN kernl policy has ExponentialBackoff retry strategy AND all attempts fail THEN 3 attempts are made`() = runTest(StandardTestDispatcher()) {
+        val eventStream = MutableSharedFlow<KernlEvent>(replay = 1)
+        val policy = KernlPolicyDefaults.copy(
+            events = eventStream,
+            retryStrategy = ExponentialBackoff()
+        )
+        val attempts = mutableListOf<Int>()
+        val subject = makeSubject(kernlPolicy = policy)
+        subject.operation = { param ->
+            attempts.add(param)
+            throw RuntimeException()
+        }
+        subject.data.test {
+            subject.fetch(42)
+            advanceUntilIdle()
+            Truth.assertThat(awaitItem() is Error).isTrue()
+            Truth.assertThat(attempts.size).isEqualTo(3)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 
     private fun TestScope.makeSubject(dispatcher: CoroutineDispatcher? = null, kernlPolicy: KernlPolicy = DefaultKernlPolicy): StubSingleCacheKernl {
         return StubSingleCacheKernl(

--- a/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlUnitTest.kt
+++ b/Kernl.Runtime/src/test/kotlin/data/repo/singlecache/BaseSingleCacheKernlUnitTest.kt
@@ -42,6 +42,7 @@ class BaseSingleCacheKernlUnitTest {
         every { DataSource.Builder } returns datasourceBuilderRequest
         every { datasourceBuilderRequest.memoryCache(String::class) } returns memoryCachedDataSourceBuilderRequest
         every { memoryCachedDataSourceBuilderRequest.dispatcher(any()) } returns memoryCachedDataSourceBuilderRequest
+        every { memoryCachedDataSourceBuilderRequest.retryStrategy(any()) } returns memoryCachedDataSourceBuilderRequest
         every { memoryCachedDataSourceBuilderRequest.build() } returns mockDataSource
     }
 

--- a/Kernl.Runtime/src/test/kotlin/kernl/data/TestKernlPolicy.kt
+++ b/Kernl.Runtime/src/test/kotlin/kernl/data/TestKernlPolicy.kt
@@ -1,20 +1,15 @@
 package kernl.data
 
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import org.mattshoe.shoebox.kernl.CacheStrategy
-import org.mattshoe.shoebox.kernl.InvalidationStrategy
-import org.mattshoe.shoebox.kernl.KernlEvent
-import org.mattshoe.shoebox.kernl.KernlPolicy
-import kotlin.time.Duration
+import org.mattshoe.shoebox.kernl.*
 
 class TestKernlPolicy: KernlPolicy {
     private val _events = MutableSharedFlow<KernlEvent>()
     override val events = _events
 
-    private var _timeToLive = Duration.INFINITE
-    override val timeToLive
-        get() = _timeToLive
+    private var _retryStrategy: RetryStrategy? = null
+    override val retryStrategy: RetryStrategy?
+        get() = _retryStrategy
 
     private var _cacheStrategy: CacheStrategy = CacheStrategy.NetworkFirst
     override val cacheStrategy: CacheStrategy
@@ -24,8 +19,8 @@ class TestKernlPolicy: KernlPolicy {
     override val invalidationStrategy: InvalidationStrategy
         get() = _invalidationStrategy
 
-    fun setTimeToLive(duration: Duration) {
-        _timeToLive = duration
+    fun setRetryStrategy(strategy: RetryStrategy) {
+        _retryStrategy = strategy
     }
 
     fun setCacheStrategy(cacheStrategy: CacheStrategy) {
@@ -35,6 +30,7 @@ class TestKernlPolicy: KernlPolicy {
     fun setInvalidationStrategy(invalidationStrategy: InvalidationStrategy) {
         _invalidationStrategy = invalidationStrategy
     }
+
 
     suspend fun event(event: KernlEvent) {
         _events.emit(event)


### PR DESCRIPTION
<!-- 
Please include the issue number in the PR title.
Example: "[#123] Add new feature to bar the foo"
-->

<!-- Link the issue associated with this PR -->
<!-- If no issue is associated with this PR, please create one for tracking purposes -->
# Issue  [#29](https://github.com/mattshoe/kernl/issues/29)

## Description
<!-- Briefly describe the changes introduced by this PR -->
- Introduced mechanism for customizing retry logic for a Kernl. 
- Implemented exponential backoff structure

## Checklist
<!-- Replace [ ] with [x] to indicate completion -->

- **I have added tests to cover any code changes**
  - [ ] Unit Tests
  - [ ] Consumer Tests (Integration tests in the Kernl.Consumer module)
  - [ ] Compilation Tests (Integration tests in the Kernl.Processor module for any KSP updates)
- **I have added new documentation for all new code and updated existing documentation:**
  - [ ] KDocs
  - [ ] README.md
  - [ ] docs/*.md
- **I have updated all existing  documentation to reflect any changes:**
  - [ ] KDocs
  - [ ] README.md
  - [ ] docs/*.md

## Additional Context
<!-- Add any other context or screenshots about the PR -->
