### PR TITLE
Enforce conflation on all aggregating flows

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,13 @@
 <!-- 
+
 Please include the issue number in the PR title.
 Example: "[#123] Add new feature to bar the foo"
+
 -->
 
 <!-- Link the issue associated with this PR -->
-<!-- If no issue is associated with this PR, please create one for tracking purposes -->
-# Issue  [#{{yourIssueNumber}}](https://github.com/mattshoe/kernl/issues/{{yourIssueNumber}})
-
-## Description
-<!-- Briefly describe the changes introduced by this PR -->
+# Issue  [#{{yourIssueNumber}}](  https://github.com/mattshoe/kernl/issues/{{yourIssueNumber}}  )
+_Briefly describe the changes introduced by this PR_
 
 ## Checklist
 <!-- Replace [ ] with [x] to indicate completion -->
@@ -17,11 +16,7 @@ Example: "[#123] Add new feature to bar the foo"
   - [ ] Unit Tests
   - [ ] Consumer Tests (Integration tests in the Kernl.Consumer module)
   - [ ] Compilation Tests (Integration tests in the Kernl.Processor module for any KSP updates)
-- **I have added new documentation for all new code and updated existing documentation:**
-  - [ ] KDocs
-  - [ ] README.md
-  - [ ] docs/*.md
-- **I have updated all existing  documentation to reflect any changes:**
+- **I have updated or created documentation to reflect any changes:**
   - [ ] KDocs
   - [ ] README.md
   - [ ] docs/*.md

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/associativecache/inmemory/BaseAssociativeCacheKernl.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/associativecache/inmemory/BaseAssociativeCacheKernl.kt
@@ -16,6 +16,7 @@ import org.mattshoe.shoebox.kernl.runtime.DataResult
 import org.mattshoe.shoebox.kernl.runtime.cache.associativecache.AssociativeMemoryCacheKernl
 import org.mattshoe.shoebox.kernl.runtime.source.DataSource
 import org.mattshoe.shoebox.kernl.runtime.dsl.kernl
+import org.mattshoe.shoebox.kernl.runtime.ext.conflatedChannelFlow
 import kotlin.reflect.KClass
 
 abstract class BaseAssociativeCacheKernl<TParams: Any, TData: Any>(
@@ -65,7 +66,7 @@ abstract class BaseAssociativeCacheKernl<TParams: Any, TData: Any>(
     }
 
     private fun initializeNewStream(params: TParams, forceFetch: Boolean): Flow<DataResult<TData>> {
-        return channelFlow {
+        return conflatedChannelFlow {
             withContext(Dispatchers.IO) {
                 loadDataIntoCache(params, forceFetch)
                 launch {

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/BaseInvalidationTracker.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/BaseInvalidationTracker.kt
@@ -3,6 +3,7 @@ package org.mattshoe.shoebox.kernl.runtime.cache.invalidation.tracker
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.conflate
 import org.mattshoe.shoebox.kernl.runtime.cache.invalidation.CountdownFlow
 import org.mattshoe.shoebox.kernl.runtime.cache.util.MonotonicStopwatch
 import org.mattshoe.shoebox.kernl.runtime.cache.util.Stopwatch
@@ -22,7 +23,7 @@ abstract class BaseInvalidationTracker(
 
     protected open val _refreshStream: Flow<Unit> = MutableSharedFlow(replay = 0)
     override val refreshStream
-        get() = _refreshStream
+        get() = _refreshStream.conflate()
 
     protected fun now(): TimeSource.Monotonic.ValueTimeMark {
         return TimeSource.Monotonic.markNow()

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/impl/EagerRefreshInvalidationTracker.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/impl/EagerRefreshInvalidationTracker.kt
@@ -6,6 +6,7 @@ import org.mattshoe.shoebox.kernl.InvalidationStrategy
 import org.mattshoe.shoebox.kernl.runtime.DataResult
 import org.mattshoe.shoebox.kernl.runtime.cache.invalidation.tracker.BaseInvalidationTracker
 import org.mattshoe.shoebox.kernl.runtime.cache.util.Stopwatch
+import org.mattshoe.shoebox.kernl.runtime.ext.conflatedChannelFlow
 import org.mattshoe.shoebox.kernl.runtime.session.KernlResourceManager
 
 class EagerRefreshInvalidationTracker(
@@ -18,7 +19,7 @@ class EagerRefreshInvalidationTracker(
     override val invalidationStream = MutableSharedFlow<Unit>()
 
     override val refreshStream: Flow<Unit>
-        get() = channelFlow {
+        get() = conflatedChannelFlow {
             kernlRegistration.timeToLiveStream
                 .onEach {
                     send(it)

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/impl/PreemptiveRefreshInvalidationTracker.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/invalidation/tracker/impl/PreemptiveRefreshInvalidationTracker.kt
@@ -7,6 +7,7 @@ import org.mattshoe.shoebox.kernl.runtime.DataResult
 import org.mattshoe.shoebox.kernl.runtime.cache.invalidation.CountdownFlow
 import org.mattshoe.shoebox.kernl.runtime.cache.invalidation.tracker.BaseInvalidationTracker
 import org.mattshoe.shoebox.kernl.runtime.cache.util.Stopwatch
+import org.mattshoe.shoebox.kernl.runtime.ext.conflatedChannelFlow
 import org.mattshoe.shoebox.kernl.runtime.session.KernlResourceManager
 
 class PreemptiveRefreshInvalidationTracker(
@@ -17,7 +18,7 @@ class PreemptiveRefreshInvalidationTracker(
     private val manualRefreshStream = MutableSharedFlow<Unit>()
 
     override val refreshStream: Flow<Unit> =
-        channelFlow {
+        conflatedChannelFlow {
             kernlRegistration.timeToLiveStream
                 .onEach {
                     println("invalidation forwarded to refresh!")

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/singlecache/inmemory/BaseSingleCacheKernl.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/cache/singlecache/inmemory/BaseSingleCacheKernl.kt
@@ -2,10 +2,8 @@ package org.mattshoe.shoebox.kernl.runtime.cache.singlecache.inmemory
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.channelFlow
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.withContext
 import org.mattshoe.shoebox.kernl.DefaultKernlPolicy
 import org.mattshoe.shoebox.kernl.KernlEvent
@@ -19,6 +17,7 @@ import org.mattshoe.shoebox.kernl.runtime.session.DefaultKernlResourceManager
 import org.mattshoe.shoebox.kernl.runtime.session.KernlResourceManager
 import org.mattshoe.shoebox.kernl.runtime.source.DataSource
 import org.mattshoe.shoebox.kernl.runtime.dsl.kernl
+import org.mattshoe.shoebox.kernl.runtime.ext.conflatedChannelFlow
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.reflect.KClass
 
@@ -43,7 +42,7 @@ abstract class BaseSingleCacheKernl<TParams: Any, TData: Any>(
 
     @Suppress("DEPRECATION_ERROR")
     override val data: Flow<DataResult<TData>>
-        get() = channelFlow {
+        get() = conflatedChannelFlow {
             // Need to make sure the KernlPolicy isn't using the global event stream already, wouldn't want dupes
             if (kernlPolicy.events !is InternalGlobalKernlEventStream) {
                 kernl { globalEventStream() }

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/ext/FlowExtensions.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/ext/FlowExtensions.kt
@@ -24,6 +24,10 @@ fun <T: Any> Flow<T>.selectivelyDistinct(predicate: suspend (T) -> Boolean): Flo
     }
 }
 
+/**
+ * This simply creates a [channelFlow] and applies the [conflate] operator to the [channelFlow]
+ * automatically.
+ */
 @OptIn(ExperimentalTypeInference::class)
 fun <T> conflatedChannelFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T>
     = channelFlow(block).conflate()

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/ext/FlowExtensions.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/ext/FlowExtensions.kt
@@ -1,7 +1,11 @@
 package org.mattshoe.shoebox.kernl.runtime.ext
 
+import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.flow
+import kotlin.experimental.ExperimentalTypeInference
 
 
 fun <T: Any> Flow<T>.selectivelyDistinct(predicate: suspend (T) -> Boolean): Flow<T> {
@@ -19,5 +23,9 @@ fun <T: Any> Flow<T>.selectivelyDistinct(predicate: suspend (T) -> Boolean): Flo
         }
     }
 }
+
+@OptIn(ExperimentalTypeInference::class)
+fun <T> conflatedChannelFlow(@BuilderInference block: suspend ProducerScope<T>.() -> Unit): Flow<T>
+    = channelFlow(block).conflate()
 
 

--- a/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/session/DefaultKernlResourceManager.kt
+++ b/Kernl.Runtime/src/main/kotlin/org/mattshoe/shoebox/kernl/runtime/session/DefaultKernlResourceManager.kt
@@ -2,6 +2,7 @@ package org.mattshoe.shoebox.kernl.runtime.session
 
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.sync.Mutex
@@ -9,6 +10,7 @@ import kotlinx.coroutines.sync.withLock
 import org.mattshoe.shoebox.kernl.NEVER
 import org.mattshoe.shoebox.kernl.runtime.cache.invalidation.CountdownFlow
 import org.mattshoe.shoebox.kernl.runtime.cache.util.MonotonicStopwatch
+import org.mattshoe.shoebox.kernl.runtime.ext.conflatedChannelFlow
 import java.lang.ref.WeakReference
 import java.util.*
 import kotlin.time.Duration
@@ -43,7 +45,7 @@ internal object DefaultKernlResourceManager: KernlResourceManager {
         val uuid = UUID.randomUUID()
         val internalTimeToLiveCountdownFlow = CountdownFlow("CountdownFlow:${kernl::class.simpleName}:${System.identityHashCode(kernl).toString(16)}")
         // We need a COLD flow that will run endlessly upon subscription but just consumes events from the "global" ttl countdown flow
-        val publicTimeToLiveFlow = channelFlow {
+        val publicTimeToLiveFlow = conflatedChannelFlow {
             internalTimeToLiveCountdownFlow.events
                 .onEach {
                     send(it)


### PR DESCRIPTION
<!-- 
Please include the issue number in the PR title.
Example: "[#123] Add new feature to bar the foo"
-->

<!-- Link the issue associated with this PR -->
<!-- If no issue is associated with this PR, please create one for tracking purposes -->
# Issue  [#61](https://github.com/mattshoe/kernl/issues/61)

## Description
<!-- Briefly describe the changes introduced by this PR -->
Instead of replace `channelFlow` with `flow`, introduced a new operator `conflatedChannelFlow` which was used in place of `channelFlow`. This seems to be ideal for our use cases, because the nature of cached data only cares about the most recent data, so queuing up outdated emissions is a pointless and wasteful practice

Therefore, all flows should be conflated to ensure only the most recent emission is respected, and outdated emissions are dropped

## Checklist
<!-- Replace [ ] with [x] to indicate completion -->

- **I have added tests to cover any code changes**
  - [x] Unit Tests
  - [x] Consumer Tests (Integration tests in the Kernl.Consumer module)
  - [x] Compilation Tests (Integration tests in the Kernl.Processor module for any KSP updates)
- **I have added new documentation for all new code and updated existing documentation:**
  - [x] KDocs
  - [x]] README.md
  - [x] docs/*.md
- **I have updated all existing  documentation to reflect any changes:**
  - [x] KDocs
  - [x] README.md
  - [x] docs/*.md

## Additional Context
<!-- Add any other context or screenshots about the PR -->
